### PR TITLE
Handle relative paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "10"
 script:
   npm run lint && npm test

--- a/lib/path-is-inside.js
+++ b/lib/path-is-inside.js
@@ -7,6 +7,9 @@ module.exports = function (thePath, potentialParent) {
     thePath = stripTrailingSep(thePath);
     potentialParent = stripTrailingSep(potentialParent);
 
+    thePath = path.resolve(thePath);
+    potentialParent = path.resolve(potentialParent);
+
     // Node treats only Windows as case-insensitive in its path module; we follow those conventions.
     if (process.platform === "win32") {
         thePath = thePath.toLowerCase();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
     "name": "path-is-inside",
     "description": "Tests whether one path is inside another path",
-    "keywords": ["path", "directory", "folder", "inside", "relative"],
+    "keywords": [
+        "path",
+        "directory",
+        "folder",
+        "inside",
+        "relative"
+    ],
     "version": "1.0.2",
     "author": "Domenic Denicola <d@domenic.me> (https://domenic.me)",
     "license": "(WTFPL OR MIT)",
@@ -16,6 +22,7 @@
     },
     "devDependencies": {
         "jshint": "~2.3.0",
-        "mocha": "~1.15.1"
+        "mocha": "~1.15.1",
+        "debug": "~1.0.4"
     }
 }


### PR DESCRIPTION
Uses [`path.resolve`](https://nodejs.org/api/path.html#path_path_resolve_paths) to handle relative paths.  
`path.resolve` returns an absolute path without `../`, so relative paths will work.

Fixes #6. 